### PR TITLE
Add Catala theme

### DIFF
--- a/themes/catala/404.etlua
+++ b/themes/catala/404.etlua
@@ -1,0 +1,42 @@
+<header>
+<h1><%= site.title %></h1>
+</header>
+<hr>
+<div class="not-found-container" style="text-align: center; padding: 50px 0;">
+    <h1>404</h1>
+    <h2>Oops, page not found.</h2>
+    
+    <p>Sorry, the page you are looking for does not exist, has moved, or perhaps never existed.</p>    
+    <p>
+        <a href="<%= pathToRoot %>index.html" class="button">Go to the home page.</a>
+    </p>
+</div>
+
+<footer>
+<hr>
+<nav class="footer-nav">
+    <div class="nav-left">
+        <span class="brand-name">
+        <a href="index.html">Link 1</a>
+        <a href="index.html">Link 2</a>
+        </span>
+    </div>
+
+    <div class="nav-right">
+        <input type="checkbox" class="toggle" title="Cambiar tema">
+        <a href="index.html" aria-label="Github">
+            <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+            </svg>
+        </a>
+        <a href="index.html" aria-label="Email">
+            <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
+        </a>
+        <a href="feed.xml"><svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 11a9 9 0 0 1 9 9"></path>
+                <path d="M4 4a16 16 0 0 1 16 16"></path>
+                <circle cx="5" cy="19" r="1"></circle>
+            </svg></a>
+    </div>
+</nav>
+</footer>

--- a/themes/catala/blog.etlua
+++ b/themes/catala/blog.etlua
@@ -1,0 +1,44 @@
+<header>
+<h1><%= site.title %></h1>
+</header>
+<p><%= site.description %></p>
+<p>Go to <a href="_test.html">Test</a>.</p>
+<hr>
+<%- postList(self) %>
+<footer>
+<hr>
+<nav class="footer-nav">
+    <div class="nav-left">
+        <span class="brand-name">
+        <a href="index.html">Link 1</a>
+        <a href="index.html">Link 2</a>
+        </span>
+    </div>
+
+    <div class="nav-center">
+        <%
+local grouped = table.groupBy(items, "keywords")
+local groups = {}
+for k, v in pairs(grouped) do table.insert(groups, { key = k }) end
+-%>
+<%- keywordList(pathToRoot, table.sorted(table.map(groups, function (g) return g.key end))) %>
+    </div>
+
+    <div class="nav-right">
+        <input type="checkbox" class="toggle" title="Cambiar tema">
+        <a href="index.html" aria-label="Github">
+            <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+            </svg>
+        </a>
+        <a href="index.html" aria-label="Email">
+            <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
+        </a>
+        <a href="feed.xml"><svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 11a9 9 0 0 1 9 9"></path>
+                <path d="M4 4a16 16 0 0 1 16 16"></path>
+                <circle cx="5" cy="19" r="1"></circle>
+            </svg></a>
+    </div>
+</nav>
+</footer>

--- a/themes/catala/index.etlua
+++ b/themes/catala/index.etlua
@@ -1,0 +1,7 @@
+<header>
+<h1>#<%= key %> | <input type="checkbox" class="toggle" title="Toggle light/dark theme"></h1>
+</header>
+<%- postList(self) %>
+<footer>
+<p>&crarr; <a href="<%= pathToRoot %>index.html">Endarrere</a>
+</footer>

--- a/themes/catala/outer.etlua
+++ b/themes/catala/outer.etlua
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title><%= site.title %></title>
+<% if description then %><meta name="description" content="<%= description %>" /><% end %>
+<% if keywords then %><meta name="keywords" content="<%= table.concat(keywords, ",") %>" /><% end %>
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+<link rel="stylesheet" href="<%= pathToRoot %>style.css" />
+<link rel="icon" href="data:," />
+<% if path == "index.html" then %><link rel="alternate" type="application/rss+xml" href="feed.xml" /><% end %>
+</head>
+<body>
+<main>
+<%- content %>
+</main>
+</body>
+</html>

--- a/themes/catala/post.etlua
+++ b/themes/catala/post.etlua
@@ -1,0 +1,46 @@
+<header>
+<h1><%= title %></h1>
+<p style="display: flex; justify-content: space-between; align-items: baseline;">
+  <span>
+    &crarr; <a href="<%= pathToRoot %>index.html">Back</a>
+  </span>
+
+  <span style="text-align: right;">
+    Publicat el <%- htmlifyDate(date) %>
+    
+    <% if keywords then -%>
+      | <%- keywordList(pathToRoot, table.sorted(keywords)) %>
+    <% end -%>
+  </span>
+</p>
+<hr>
+</header>
+<%- content %>
+<footer>
+<hr>
+<nav class="footer-nav">
+    <div class="nav-left">
+        <span class="brand-name">
+        <a href="index.html">Link 1</a>
+        <a href="index.html">Link 2</a>
+        </span>
+    </div>
+
+    <div class="nav-right">
+        <input type="checkbox" class="toggle" title="Toggle light/dark theme">
+        <a href="index.html" aria-label="Github">
+            <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+            </svg>
+        </a>
+        <a href="index.html" aria-label="Email">
+            <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
+        </a>
+        <a href="feed.xml"><svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 11a9 9 0 0 1 9 9"></path>
+                <path d="M4 4a16 16 0 0 1 16 16"></path>
+                <circle cx="5" cy="19" r="1"></circle>
+            </svg></a>
+    </div>
+</nav>
+</footer>

--- a/themes/catala/style.css
+++ b/themes/catala/style.css
@@ -1,0 +1,291 @@
+/* --- Variables & Dark Mode --- */
+:root {
+  --bg-body: #F5F5F0;
+  --text-body: #222;
+  --a-body: #1a1a1a;
+  --thead-body: #0000000d;
+  --icon-body: #1a1a1a;
+  --code-body: #222; 
+  --card-bg: #fff;
+  --lighter: #888;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-body: #27282a;
+    --text-body: #f0f0f0;
+    --a-body: #dbdbdb;
+    --thead-body: #444548;
+    --icon-body: #F5F5F0;
+    --card-bg: #333;
+    --code-body: #f5f5f0; 
+  }
+}
+
+body:has(.toggle:checked) {
+  --bg-body: #27282a;
+  --text-body: #f0f0f0;
+  --a-body: #dbdbdb;
+  --thead-body: #444548;
+  --icon-body: #F5F5F0;
+  --card-bg: #333;
+  --code-body: #f5f5f0; 
+}
+
+/* --- Base & Typo --- */
+html {
+  font-family: Palatino, Georgia, Lucida Bright, Book Antiqua, serif;
+  font-size: 16px;
+  line-height: 1.5rem;
+}
+
+body {
+  background-color: var(--bg-body);
+  color: var(--text-body);
+  transition: background-color 0.5s ease, color 0.5s ease;
+  margin: 1.5rem 1ch;
+}
+
+h1, h2, h3, h4, h5, h6, th { font-weight: normal; }
+h1, h2, h3 { line-height: 3rem; margin: 1.5rem 0 0; }
+h1 { font-size: 2.488em; }
+h2 { font-size: 2.074em; }
+h3 { font-size: 1.728em; }
+h4 { font-size: 1.44em; }
+h5 { font-size: 1.2em; }
+h6 { font-size: 1em; }
+small, sup, sub { font-size: 0.833em; }
+sup, sub { line-height: 1em; }
+
+p, ul, ol, dl, table, blockquote, pre { margin: 1.5rem 0 0; }
+
+/* --- Links --- */
+a, header nav a:visited, a code {
+  color: var(--a-body);
+  text-decoration: underline dotted 1px;
+}
+a:visited, a:visited code { color: var(--a-body); }
+a:hover { text-decoration: underline wavy 1px; }
+
+mark {
+  color: inherit;
+  background-color: #fe0;
+  padding: 1px;
+}
+
+ins {
+  border: solid var(--thead-body);
+  border-width: 1px;
+  padding: 1px;
+  text-decoration: none;
+}
+
+/* --- CODE, PRE, SAMP, KBD --- */
+code, pre, samp, kbd {
+  font-family: Consolas, Liberation Mono, Menlo, Courier, monospace;
+  font-size: 0.833rem;
+  color: var(--code-body);
+}
+kbd { font-weight: bold; }
+
+/* Code+Table */
+code, pre, samp, thead, tfoot { background-color: var(--thead-body); }
+
+code, samp {
+  border: solid rgba(0, 0, 0, 0.1);
+  border-width: 1px;
+  border-radius: 2px;
+  padding: 0.1em 0.2em;
+  white-space: nowrap;
+}
+
+pre {
+  border: solid rgba(0, 0, 0, 0.1);
+  border-width: 1px;
+  border-radius: 2px;
+  padding: 0 0.5ch;
+  overflow-x: auto;
+  margin-top: calc(1.5rem - 1px);
+  margin-bottom: -1px;
+}
+
+pre code {
+  border: none;
+  padding: 0;
+  background-color: transparent;
+  white-space: inherit;
+}
+
+/* --- Layout --- */
+body > header { text-align: center; }
+
+main, body > footer {
+  display: block;
+  margin: 5rem auto;
+  width: 50%;
+  font-size: 125%;
+  line-height: 150%;
+}
+
+main figure, main aside {
+  float: right;
+  margin: 1.5rem 0 0 1ch;
+}
+
+main aside {
+  max-width: 26ch;
+  border: solid var(--thead-body);
+  border-width: 0 0 0 0.5ch;
+  padding: 0 0 0 0.5ch;
+}
+
+blockquote {
+  border: solid var(--thead-body);
+  border-width: 0 0 0 0.5ch;
+  margin-right: 3ch;
+  margin-left: 1.5ch;
+  padding: 0 0 0 1ch;
+}
+
+hr {
+  border-top: medium none;
+  border-bottom: 1px solid hsl(0, 0%, 70%); /* Simplificado */
+  margin: 1.5rem 0;
+}
+
+img { max-width: 100%; }
+
+/* --- Lists --- */
+ul, ol, dd { padding: 0; }
+ul ul, ol ol, ul ol, ol ul { margin: 0; }
+dd { margin: 0; }
+ul > li { list-style-type: disc; }
+li ul > li { list-style-type: circle; }
+li li ul > li { list-style-type: square; }
+ol > li { list-style-type: decimal; }
+li ol > li { list-style-type: lower-roman; }
+li li ol > li { list-style-type: lower-alpha; }
+
+nav ul { padding: 0; list-style-type: none; }
+nav ul li { display: inline; padding-left: 1ch; white-space: nowrap; }
+nav ul li:first-child { padding-left: 0; }
+
+/* --- Tables --- */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  overflow-x: auto;
+  line-height: calc(1.5rem - 1px);
+  margin-bottom: -1px;
+}
+th, td {
+  border: solid #dbdbdb;
+  border-width: 1px;
+  padding: 0 0.5ch;
+}
+
+/* Toggle Light-Dark */
+.toggle {
+  --size: 20px;
+  appearance: none;
+  outline: none;
+  cursor: pointer;
+  width: var(--size);
+  height: var(--size);
+  box-shadow: inset calc(var(--size) * 0.33) calc(var(--size) * -0.25) 0;
+  border-radius: 999px;
+  color: #222;
+  transition: all 500ms;
+  position: relative; 
+}
+
+.toggle:checked {
+  --ray-size: calc(var(--size) * -0.4);
+  --offset-orthogonal: calc(var(--size) * 0.65);
+  --offset-diagonal: calc(var(--size) * 0.45);
+  transform: scale(0.75);
+  color: hsl(40, 100%, 50%);
+  box-shadow: 
+    inset 0 0 0 var(--size),
+    calc(var(--offset-orthogonal) * -1) 0 0 var(--ray-size),
+    var(--offset-orthogonal) 0 0 var(--ray-size),
+    0 calc(var(--offset-orthogonal) * -1) 0 var(--ray-size),
+    0 var(--offset-orthogonal) 0 var(--ray-size),
+    calc(var(--offset-diagonal) * -1) calc(var(--offset-diagonal) * -1) 0 var(--ray-size),
+    var(--offset-diagonal) var(--offset-diagonal) 0 var(--ray-size),
+    calc(var(--offset-diagonal) * -1) var(--offset-diagonal) 0 var(--ray-size),
+    var(--offset-diagonal) calc(var(--offset-diagonal) * -1) 0 var(--ray-size);
+}
+
+/* Flex */
+.item-flex {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.item-flex span { margin-left: 10%; }
+
+/* Footer-Nav */
+.footer-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 2rem;
+  font-family: sans-serif;
+}
+.footer-nav .brand-name, .footer-nav .nav-center a {
+  color: #555;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+.footer-nav .brand-name { font-size: 1rem; gap: 15px; display: flex; }
+.footer-nav .nav-center a { margin: 0 10px; }
+.footer-nav .nav-right { display: flex; gap: 15px; }
+.footer-nav .nav-right a {
+  color: var(--icon-body);
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+.footer-nav .nav-right a:hover { color: #6b6b6b; }
+
+/* Syntax Highlighting */
+.hl-comment, .hl-operator { font-style: italic; color: var(--lighter); }
+.hl-preprocessor { font-weight: bold; font-style: italic; }
+.hl-tag, .hl-function, .hl-heading, .hl-label { font-weight: bold; }
+.hl-reference, .hl-variable, .hl-code, .hl-embedded, .hl-identifier { font-weight: normal; }
+.hl-annotation, .hl-class, .hl-type, .hl-keyword { font-weight: bolder; }
+.hl-attribute, .hl-constant { font-weight: normal; }
+.hl-bold, .hl-italic, .hl-number, .hl-underline, .hl-string { font-style: italic; }
+.hl-link, .hl-list, .hl-error, .hl-regex { font-style: italic; text-decoration: underline; }
+
+/* --- Responsive --- */
+@media screen and (max-width: 900px) {
+  main, body > footer {
+      width: 90%;
+      margin-top: 2rem;
+      margin-bottom: 2rem;
+      font-size: 110%;
+  }
+  main figure, main aside {
+      float: none;
+      display: block;
+      width: 100%;
+      margin: 1.5rem 0;
+  }
+  main aside {
+      border-width: 0 0 0 4px;
+      background-color: rgba(0,0,0,0.02);
+      padding: 0.5rem 1rem;
+  }
+  blockquote { margin-right: 0; margin-left: 0; }
+  .item-flex { flex-direction: column; align-items: flex-start; }
+  .item-flex span { margin-left: 0; margin-top: 0.5rem; }
+  nav ul li { display: inline-block; white-space: normal; margin-bottom: 0.5rem; }
+}
+
+@media screen and (max-width: 600px) {
+  .footer-nav { flex-direction: column; gap: 1.5rem; }
+  .nav-left, .nav-center, .nav-right { width: 100%; justify-content: center; text-align: center; }
+}

--- a/themes/catala/theme.lua
+++ b/themes/catala/theme.lua
@@ -1,0 +1,126 @@
+shared = require("themes.shared")
+
+-- Helpers
+local htmlDateTemplate = etlua.compile([[<time datetime="<%= short %>"><%= long %></time>]])
+local months = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" }
+function htmlifyDateShort(date)
+	local year, month, day = string.match(date, "^(%d%d%d%d)-(%d%d)-(%d%d)")
+	return htmlDateTemplate({ short = date, long = months[string.toNumber(month)] .. " " .. day })
+end
+
+function htmlifyDate(date)
+	return htmlDateTemplate({ short = date, long = shared.formatDate(date) })
+end
+
+local keywordListTemplate = etlua.compile([[<%
+for i, k in ipairs(keywords) do -%><% if i > 1 then %> | <% end %><a href="<%= pathToRoot %>topics/<%= k %>.html">#<%= k %></a>
+<% end -%>]])
+function keywordList(pathToRoot, keywords)
+	return keywordListTemplate({ pathToRoot = pathToRoot, keywords = keywords })
+end
+
+local postListTemplate = etlua.compile([[<% local lastYear = nil -%>
+<% for i, item in ipairs(table.sortBy(items, "date", true)) do
+   local year = string.match(item.date, "^(%d%d%d%d)")
+   if lastYear ~= year then
+     if lastYear ~= nil then -%>
+</ul>
+<% end -%>
+<h2><%= year %></h2>
+<ul class="posts">
+<%
+	 lastYear = year
+   end
+-%>
+<li class="item-flex"><a href="<%= pathToRoot %><%= item.path %>"><%= item.title %></a> <span><%- htmlifyDateShort(item.date) %></span></li>
+<% end -%>
+<% if #items > 0 then -%>
+</ul>
+<% end -%>
+]])
+function postList(self)
+	return postListTemplate({ pathToRoot = self.pathToRoot, items = self.items })
+end
+
+-- Hard-code syntax highlighting as normal HTML markup to support non-CSS browsers (e.g. terminal browsers)
+local tagToElement = {}
+for e, list in pairs({
+	i = {"comment", "preprocessor", "bold", "italic", "number", "underline", "string"},
+	b = {"tag", "function", "heading", "label", "annotation", "class", "type", "keyword"},
+	u = {"link", "list", "error", "regex"},
+}) do
+	for _, t in ipairs(list) do
+		tagToElement[t] = e
+	end
+end
+
+local function highlightSpan(verbatim, tag)
+	local element = tagToElement[tag] or "span"
+	return "<" .. element .. " class=\"hl-" .. tag .. "\">" .. verbatim .. "</" .. element .. ">"
+end
+
+-- Site metadata
+local site = {
+	title = "Untitled",
+	url = "https://example.com/",
+    description = "Some text",
+}
+
+local siteOverrides = fs.tryLoadFile("site.lua")
+if siteOverrides then
+	table.merge(siteOverrides(), site)
+end
+
+local source = args[3] or "content"
+local destination = args[4] or "out"
+
+-- Build pipeline
+return {
+    readFromSource(source),
+    injectFiles({ 
+        ["style.css"] = fs.readThemeFile("style.css"), 
+        ["_404.html"] = "",
+    }),
+
+    processMarkdown(),
+    omitWhen(function (item) return item.path == "site.lua" end),
+    highlightSyntax(highlightSpan),
+
+    -- 404.etlua
+    injectMetadata({
+        title = "404 - Not found", 
+        pathToRoot = site.url,
+        date = "1970-01-01",
+    }, "^_404.html$"),
+
+    -- Filter 
+    aggregate("feed.xml", "^[^_].*%.html$"),
+    aggregate("index.html", "^[^_].*%.html$"),
+
+    -- Keywords
+    createIndexes(function (keyword) return "topics/" .. keyword .. ".html" end, "keywords", "^[^_].*%.html$"),
+    deriveMetadata({ title = function (item) return item.key end }, "^topics/.-%.html$"),
+    injectMetadata({ site = site }),
+    
+    -- Templates
+    applyTemplates({
+        
+        { "%.html$", fs.readThemeFile("post.etlua") },
+        { "^topics/.-%.html$", fs.readThemeFile("index.etlua") },
+        { "^feed.xml$", fs.readThemeFile("../shared/feed.etlua") },
+        { "^index.html$", fs.readThemeFile("blog.etlua") },
+        { "^_404.html$", fs.readThemeFile("404.etlua") },
+    }),
+    applyTemplates({ { "%.html$", fs.readThemeFile("outer.etlua") } }),
+
+    -- Using an underscore for _404.html keeps it out of article lists. The file is built using its own template and then renamed after generation.
+    omitWhen(function(item)
+        if item.path == "_404.html" then
+            item.path = "404.html"
+        end
+        return false
+    end),
+
+    checkLinks(),
+    writeToDestination(destination),
+}


### PR DESCRIPTION
Hello! This is my first pull request, so please be gentle if I messed anything up, though I basically only added the "themes/catala" folder. If you want to see the theme in action, you can check out my personal blog (written in Catalan) here: https://avilagrijalva.github.io/_test.html

The theme focuses on text readability, and I have added features that I consider essential for a blog:

- A footer for shortcuts to useful links.
- A light/dark mode toggle button.
- `site.description` in `theme.lua` for a brief blog description.
- A 404 page (https://avilagrijalva.github.io/404.html)
- Drafts or Markdown files that I don't want appearing in the index list but still want generated so they can be accessed via a direct link. This is achieved via `^[^_].*%.html$`, meaning all Markdown files starting with an underscore will be treated this way.